### PR TITLE
[DocFix] Corrected example values

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ Usage
 
 You can also write back through the wrapper with indifferent access
 
-    struct = DeepStruct.wrap({:a => 1, "b" => 2})
+    struct = DeepStruct.wrap({:a => 10, "b" => 20})
     struct.a = 10
     struct.b = 20
     struct


### PR DESCRIPTION
Wrong input values were given in the example, which has been changed to the right ones. 
